### PR TITLE
Ignore ascii equals found in string value when parsing FIX message

### DIFF
--- a/nanofix-client/src/main/java/com/lmax/nanofix/incoming/FixTagParser.java
+++ b/nanofix-client/src/main/java/com/lmax/nanofix/incoming/FixTagParser.java
@@ -46,13 +46,15 @@ public final class FixTagParser
 
         int tagStart = offset;
         int equalsIndex = -1;
+        boolean metFirstAsciiEquals = false;
 
         for (int i = 0; i < length; i++)
         {
             int index = i + offset;
-            if (ASCII_EQUALS == message[index])
+            if (!metFirstAsciiEquals && ASCII_EQUALS == message[index])
             {
                 equalsIndex = index;
+                metFirstAsciiEquals = true;
             }
 
             if (containsLineSeparator(message[index]))
@@ -74,6 +76,7 @@ public final class FixTagParser
                     final int tagValueLength = index - tagValueOffset;
 
                     fixTagHandler.onTag(tagIdentity, message, tagValueOffset, tagValueLength);
+                    metFirstAsciiEquals = false;
 
                     if (fixTagHandler.isFinished())
                     {

--- a/nanofix-client/src/main/java/com/lmax/nanofix/incoming/FixTagParser.java
+++ b/nanofix-client/src/main/java/com/lmax/nanofix/incoming/FixTagParser.java
@@ -46,15 +46,13 @@ public final class FixTagParser
 
         int tagStart = offset;
         int equalsIndex = -1;
-        boolean metFirstAsciiEquals = false;
 
         for (int i = 0; i < length; i++)
         {
             int index = i + offset;
-            if (!metFirstAsciiEquals && ASCII_EQUALS == message[index])
+            if (-1 == equalsIndex && ASCII_EQUALS == message[index])
             {
                 equalsIndex = index;
-                metFirstAsciiEquals = true;
             }
 
             if (containsLineSeparator(message[index]))
@@ -76,7 +74,6 @@ public final class FixTagParser
                     final int tagValueLength = index - tagValueOffset;
 
                     fixTagHandler.onTag(tagIdentity, message, tagValueOffset, tagValueLength);
-                    metFirstAsciiEquals = false;
 
                     if (fixTagHandler.isFinished())
                     {

--- a/nanofix-client/src/main/java/com/lmax/nanofix/incoming/FixTagParser.java
+++ b/nanofix-client/src/main/java/com/lmax/nanofix/incoming/FixTagParser.java
@@ -55,7 +55,7 @@ public final class FixTagParser
                 equalsIndex = index;
             }
 
-            if (containsLineSeparator(message[index]))
+            if (isLineSeparator(message[index]))
             {
                 if (-1 != equalsIndex)
                 {
@@ -91,11 +91,11 @@ public final class FixTagParser
         return true;
     }
 
-    private boolean containsLineSeparator(final byte separator)
+    private boolean isLineSeparator(final byte charByte)
     {
         for (final byte lineSeparator : lineSeparators)
         {
-            if (lineSeparator == separator)
+            if (lineSeparator == charByte)
             {
                 return true;
             }

--- a/nanofix-client/src/test/java/com/lmax/nanofix/incoming/FixTagParserTest.java
+++ b/nanofix-client/src/test/java/com/lmax/nanofix/incoming/FixTagParserTest.java
@@ -17,6 +17,7 @@
 package com.lmax.nanofix.incoming;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -127,6 +128,24 @@ public final class FixTagParserTest
         inOrder.verify(fixTagHandler).onTag(35, newOrderSingleMsg, 19, 1);
         inOrder.verify(fixTagHandler, times(1)).isFinished();
 
+        inOrder.verify(fixTagHandler).messageEnd();
+    }
+
+    @Test
+    public void shouldIgnoreEqualsCharInStringValue()
+    {
+        final byte[] msg = "8=FIX.4.4|9=131|35=j|58=Invalid request type [263=3]|10=029|".getBytes(StandardCharsets.US_ASCII);
+
+        final FixTagParser parser = new FixTagParser(fixTagHandler, new byte[]{124});
+        parser.parse(msg, 0, msg.length, true);
+
+        InOrder inOrder = BDDMockito.inOrder(fixTagHandler);
+        inOrder.verify(fixTagHandler).messageStart();
+        inOrder.verify(fixTagHandler).onTag(8, msg, 2, 7);
+        inOrder.verify(fixTagHandler).onTag(9, msg, 12, 3);
+        inOrder.verify(fixTagHandler).onTag(35, msg, 19, 1);
+        inOrder.verify(fixTagHandler).onTag(58, msg, 24, 28);
+        inOrder.verify(fixTagHandler).onTag(10, msg, 56, 3);
         inOrder.verify(fixTagHandler).messageEnd();
     }
 }


### PR DESCRIPTION
**Issue**
When `=` char exists in tag values, `FixTagParser` always takes the last `=` found before next line separator and so it raises exception due to invalid tag id.

**Changes**
Always assume the first `=` char as the correct tag separator and ignore the rest.