### PR TITLE
Bump Gradle Build GitHub Actions Plugin to 2.4.2

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,6 +29,6 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
+      uses: gradle/gradle-build-action@v2.4.2
       with:
         arguments: build


### PR DESCRIPTION
Resolves CVE-2023-30853, although given that we don't use secrets in the GitHub Actions pipeline the risk is minimal.
