### PR TITLE
Update to Java 1.8 and replace Joda with Java time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ allprojects {
 
     defaultTasks 'build'
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
 
 

--- a/nanofix-client/build.gradle
+++ b/nanofix-client/build.gradle
@@ -19,7 +19,5 @@ dependencies {
     implementation 'com.google.guava:guava:13.0'
     implementation 'com.google.code.findbugs:jsr305:1.3.9'
     implementation 'org.slf4j:slf4j-api:1.7.16'
-    implementation 'joda-time:joda-time:2.5'
-
 
 }

--- a/nanofix-client/src/main/java/com/lmax/nanofix/FixUtil.java
+++ b/nanofix-client/src/main/java/com/lmax/nanofix/FixUtil.java
@@ -18,12 +18,10 @@ package com.lmax.nanofix;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 import com.lmax.nanofix.incoming.FixTagParser;
-
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 public final class FixUtil
 {
@@ -34,7 +32,7 @@ public final class FixUtil
             ASCII_CHARSET = StandardCharsets.US_ASCII;
     }
 
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormat.forPattern("YYYYMMdd-HH:mm:ss.SSS").withZone(DateTimeZone.UTC);
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 
     public static Charset getCharset()
     {

--- a/nanofix-client/src/main/java/com/lmax/nanofix/outgoing/FixMessageBuilder.java
+++ b/nanofix-client/src/main/java/com/lmax/nanofix/outgoing/FixMessageBuilder.java
@@ -18,15 +18,13 @@ package com.lmax.nanofix.outgoing;
 
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
+import java.time.LocalDateTime;
 
 import com.lmax.nanofix.fields.BusinessRejectionReason;
 import com.lmax.nanofix.fields.EncryptMethod;
 import com.lmax.nanofix.fields.MsgType;
 import com.lmax.nanofix.fields.SessionRejectReason;
 import com.lmax.nanofix.fields.Tags;
-
-import org.joda.time.DateTime;
-
 
 import static com.lmax.nanofix.fields.Tags.BeginSeqNo;
 import static com.lmax.nanofix.fields.Tags.BusinessRejectReason;
@@ -176,9 +174,9 @@ public class FixMessageBuilder
         return addTag(MsgSeqNum.getTag(), msgSeqNum);
     }
 
-    public FixMessageBuilder sendingTime(final DateTime sendingTime)
+    public FixMessageBuilder sendingTime(final LocalDateTime sendingTime)
     {
-        return addTag(SendingTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.print(sendingTime));
+        return addTag(SendingTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.format(sendingTime));
     }
 
     public FixMessageBuilder username(final String username)
@@ -222,9 +220,9 @@ public class FixMessageBuilder
         return addTag(Side.getTag(), Integer.toString(side.getCode()));
     }
 
-    public FixMessageBuilder transactionTime(final DateTime transactionTime)
+    public FixMessageBuilder transactionTime(final LocalDateTime transactionTime)
     {
-        return addTag(TransactTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.print(transactionTime));
+        return addTag(TransactTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.format(transactionTime));
     }
 
     public FixMessageBuilder orderQty(final BigDecimal orderQty)
@@ -272,9 +270,9 @@ public class FixMessageBuilder
         return addTag(Tags.PossDupFlag.getTag(), possDup ? "Y" : "N");
     }
 
-    public FixMessageBuilder origSendingTime(final DateTime origSendingTime)
+    public FixMessageBuilder origSendingTime(final LocalDateTime origSendingTime)
     {
-        return addTag(OrigSendingTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.print(origSendingTime));
+        return addTag(OrigSendingTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.format(origSendingTime));
     }
 
 

--- a/nanofix-client/src/main/java/com/lmax/nanofix/outgoing/FixMessageBuilder.java
+++ b/nanofix-client/src/main/java/com/lmax/nanofix/outgoing/FixMessageBuilder.java
@@ -18,7 +18,7 @@ package com.lmax.nanofix.outgoing;
 
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import com.lmax.nanofix.fields.BusinessRejectionReason;
 import com.lmax.nanofix.fields.EncryptMethod;
@@ -174,7 +174,7 @@ public class FixMessageBuilder
         return addTag(MsgSeqNum.getTag(), msgSeqNum);
     }
 
-    public FixMessageBuilder sendingTime(final LocalDateTime sendingTime)
+    public FixMessageBuilder sendingTime(final ZonedDateTime sendingTime)
     {
         return addTag(SendingTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.format(sendingTime));
     }
@@ -220,7 +220,7 @@ public class FixMessageBuilder
         return addTag(Side.getTag(), Integer.toString(side.getCode()));
     }
 
-    public FixMessageBuilder transactionTime(final LocalDateTime transactionTime)
+    public FixMessageBuilder transactionTime(final ZonedDateTime transactionTime)
     {
         return addTag(TransactTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.format(transactionTime));
     }
@@ -270,7 +270,7 @@ public class FixMessageBuilder
         return addTag(Tags.PossDupFlag.getTag(), possDup ? "Y" : "N");
     }
 
-    public FixMessageBuilder origSendingTime(final LocalDateTime origSendingTime)
+    public FixMessageBuilder origSendingTime(final ZonedDateTime origSendingTime)
     {
         return addTag(OrigSendingTime.getTag(), com.lmax.nanofix.FixUtil.DATE_TIME_FORMATTER.format(origSendingTime));
     }

--- a/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/FixMessageBuilderTest.java
+++ b/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/FixMessageBuilderTest.java
@@ -1,11 +1,10 @@
 package com.lmax.nanofix.outgoing;
 
 
+import java.time.LocalDateTime;
+
 import com.lmax.nanofix.fields.EncryptMethod;
 import com.lmax.nanofix.fields.MsgType;
-
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -15,37 +14,37 @@ public class FixMessageBuilderTest
 {
 
     @Test
-    public void shouldBuildFix44MessageByDefault() throws Exception
+    public void shouldBuildFix44MessageByDefault()
     {
         final FixMessage fixMessage = new FixMessageBuilder().messageType(MsgType.LOGIN).senderCompID("SenderCompID").
-                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(new DateTime(2016, 1, 2, 3, 4, DateTimeZone.UTC)).build();
+                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(LocalDateTime.of(2016, 1, 2, 3, 4)).build();
         final String expectedFixMessage = fixMessage.toFixString();
         assertThat(expectedFixMessage, is("8=FIX.4.4\u00019=78\u000135=A\u0001" +
                                           "49=SenderCompID\u000156=TargetCompId\u000198=0\u0001108=1\u000134=1\u000152=20160102-03:04:00.000\u000110=214\u0001"));
     }
 
     @Test
-    public void shouldBuildFix42MessageWhenSpecified() throws Exception
+    public void shouldBuildFix42MessageWhenSpecified()
     {
         final FixMessage fixMessage = new FixMessageBuilder("FIX.4.2").messageType(MsgType.LOGIN).senderCompID("SenderCompID").
-                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(new DateTime(2016, 1, 2, 3, 4, DateTimeZone.UTC)).build();
+                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(LocalDateTime.of(2016, 1, 2, 3, 4)).build();
         final String expectedFixMessage = fixMessage.toFixString();
         assertThat(expectedFixMessage, is("8=FIX.4.2\u00019=78\u000135=A\u0001" +
                                           "49=SenderCompID\u000156=TargetCompId\u000198=0\u0001108=1\u000134=1\u000152=20160102-03:04:00.000\u000110=212\u0001"));
     }
 
     @Test
-    public void shouldBuildFix424MessageWithRawData() throws Exception
+    public void shouldBuildFix424MessageWithRawData()
     {
         final FixMessage fixMessage = new FixMessageBuilder("FIX.4.2").messageType(MsgType.LOGIN).senderCompID("SenderCompID").
-                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).rawData("RawData").heartBtInt(1).msgSeqNum(1).sendingTime(new DateTime(2016, 1, 2, 3, 4, DateTimeZone.UTC)).build();
+                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).rawData("RawData").heartBtInt(1).msgSeqNum(1).sendingTime(LocalDateTime.of(2016, 1, 2, 3, 4)).build();
         final String expectedFixMessage = fixMessage.toFixString();
         assertThat(expectedFixMessage, is("8=FIX.4.2\u00019=94\u000135=A\u000149=SenderCompID\u000156=TargetCompId\u0001" +
                                           "98=0\u000195=7\u000196=RawData\u0001108=1\u000134=1\u000152=20160102-03:04:00.000\u000110=006\u0001"));
     }
 
     @Test
-    public void shouldBeAbleToBuildMessageWithArbitaryTagAndValue() throws Exception
+    public void shouldBeAbleToBuildMessageWithArbitaryTagAndValue()
     {
         final FixMessage fixMessage = new FixMessageBuilder("FIX.99").append(666666, "JunkData").build();
         final String expectedFixMessage = fixMessage.toFixString();

--- a/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/FixMessageBuilderTest.java
+++ b/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/FixMessageBuilderTest.java
@@ -2,6 +2,8 @@ package com.lmax.nanofix.outgoing;
 
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import com.lmax.nanofix.fields.EncryptMethod;
 import com.lmax.nanofix.fields.MsgType;
@@ -13,11 +15,13 @@ import static org.junit.Assert.assertThat;
 public class FixMessageBuilderTest
 {
 
+    private static final ZonedDateTime SENDING_TIME = ZonedDateTime.of(LocalDateTime.of(2016, 1, 2, 3, 4), ZoneOffset.UTC);
+
     @Test
     public void shouldBuildFix44MessageByDefault()
     {
         final FixMessage fixMessage = new FixMessageBuilder().messageType(MsgType.LOGIN).senderCompID("SenderCompID").
-                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(LocalDateTime.of(2016, 1, 2, 3, 4)).build();
+                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(SENDING_TIME).build();
         final String expectedFixMessage = fixMessage.toFixString();
         assertThat(expectedFixMessage, is("8=FIX.4.4\u00019=78\u000135=A\u0001" +
                                           "49=SenderCompID\u000156=TargetCompId\u000198=0\u0001108=1\u000134=1\u000152=20160102-03:04:00.000\u000110=214\u0001"));
@@ -27,7 +31,7 @@ public class FixMessageBuilderTest
     public void shouldBuildFix42MessageWhenSpecified()
     {
         final FixMessage fixMessage = new FixMessageBuilder("FIX.4.2").messageType(MsgType.LOGIN).senderCompID("SenderCompID").
-                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(LocalDateTime.of(2016, 1, 2, 3, 4)).build();
+                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).heartBtInt(1).msgSeqNum(1).sendingTime(SENDING_TIME).build();
         final String expectedFixMessage = fixMessage.toFixString();
         assertThat(expectedFixMessage, is("8=FIX.4.2\u00019=78\u000135=A\u0001" +
                                           "49=SenderCompID\u000156=TargetCompId\u000198=0\u0001108=1\u000134=1\u000152=20160102-03:04:00.000\u000110=212\u0001"));
@@ -37,7 +41,7 @@ public class FixMessageBuilderTest
     public void shouldBuildFix424MessageWithRawData()
     {
         final FixMessage fixMessage = new FixMessageBuilder("FIX.4.2").messageType(MsgType.LOGIN).senderCompID("SenderCompID").
-                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).rawData("RawData").heartBtInt(1).msgSeqNum(1).sendingTime(LocalDateTime.of(2016, 1, 2, 3, 4)).build();
+                targetCompID("TargetCompId").encryptMethod(EncryptMethod.NONE).rawData("RawData").heartBtInt(1).msgSeqNum(1).sendingTime(SENDING_TIME).build();
         final String expectedFixMessage = fixMessage.toFixString();
         assertThat(expectedFixMessage, is("8=FIX.4.2\u00019=94\u000135=A\u000149=SenderCompID\u000156=TargetCompId\u0001" +
                                           "98=0\u000195=7\u000196=RawData\u0001108=1\u000134=1\u000152=20160102-03:04:00.000\u000110=006\u0001"));

--- a/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/OutboundMessageHandlerTest.java
+++ b/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/OutboundMessageHandlerTest.java
@@ -21,6 +21,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.WritableByteChannel;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -62,10 +65,11 @@ public class OutboundMessageHandlerTest
     @Test
     public void shouldPlaceMultipleMessagesInSameBuffer() throws Exception
     {
+        final ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("19981231-23:58:59.000", DATE_TIME_FORMATTER), ZoneOffset.UTC);
         final FixMessage loginMessage = new FixMessageBuilder().messageType(MsgType.LOGIN).msgSeqNum(1).senderCompID("username").targetCompID("LMXBL").
-                sendingTime(LocalDateTime.parse("19981231-23:58:59.000", DATE_TIME_FORMATTER)).username("username").password("password").heartBtInt(100000).encryptMethod(EncryptMethod.NONE).build();
+                sendingTime(zonedDateTime).username("username").password("password").heartBtInt(100000).encryptMethod(EncryptMethod.NONE).build();
         final FixMessage logoutMessage = new FixMessageBuilder().messageType(MsgType.LOGOUT).msgSeqNum(2).senderCompID("username").targetCompID("LMXBL").
-                sendingTime(LocalDateTime.parse("19981231-23:59:59.000", DATE_TIME_FORMATTER)).build();
+                sendingTime(zonedDateTime.plusMinutes(1)).build();
         final List<FixMessage> expected = newArrayList(loginMessage, logoutMessage);
 
         mockery.checking(new Expectations()

--- a/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/OutboundMessageHandlerTest.java
+++ b/nanofix-client/src/test/java/com/lmax/nanofix/outgoing/OutboundMessageHandlerTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.WritableByteChannel;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,7 +32,6 @@ import com.lmax.nanofix.transport.TransportClosedException;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,9 +63,9 @@ public class OutboundMessageHandlerTest
     public void shouldPlaceMultipleMessagesInSameBuffer() throws Exception
     {
         final FixMessage loginMessage = new FixMessageBuilder().messageType(MsgType.LOGIN).msgSeqNum(1).senderCompID("username").targetCompID("LMXBL").
-                sendingTime(DateTime.parse("19981231-23:58:59.000", DATE_TIME_FORMATTER)).username("username").password("password").heartBtInt(100000).encryptMethod(EncryptMethod.NONE).build();
+                sendingTime(LocalDateTime.parse("19981231-23:58:59.000", DATE_TIME_FORMATTER)).username("username").password("password").heartBtInt(100000).encryptMethod(EncryptMethod.NONE).build();
         final FixMessage logoutMessage = new FixMessageBuilder().messageType(MsgType.LOGOUT).msgSeqNum(2).senderCompID("username").targetCompID("LMXBL").
-                sendingTime(DateTime.parse("19981231-23:59:59.000", DATE_TIME_FORMATTER)).build();
+                sendingTime(LocalDateTime.parse("19981231-23:59:59.000", DATE_TIME_FORMATTER)).build();
         final List<FixMessage> expected = newArrayList(loginMessage, logoutMessage);
 
         mockery.checking(new Expectations()


### PR DESCRIPTION
Upgraded Java from 7 to 8 and removed Joda time in favour of Java's LocalDateTime